### PR TITLE
Fix cost value TypeError

### DIFF
--- a/sc_cost_meter/app.py
+++ b/sc_cost_meter/app.py
@@ -6,6 +6,18 @@ from datetime import datetime, timedelta
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
+
+def get_time_period_yesterday():
+  current_time = datetime.utcnow()
+  start_time = current_time - timedelta(days=2)
+  end_time = current_time - timedelta(days=1)
+  time_period = {
+    "Start": start_time.strftime('%Y-%m-%d'),
+    "End": end_time.strftime('%Y-%m-%d')
+  }
+
+  return time_period
+
 def lambda_handler(event, context):
   synapse_ids = utils.get_marketplace_synapse_ids()
   log.debug(f'customers list: {synapse_ids}')
@@ -14,14 +26,6 @@ def lambda_handler(event, context):
     log.debug(f'marketplace customer ID: {customer_id}')
     product_code = utils.get_marketplace_product_code(synapse_id)
     log.debug(f'marketplace product code: {product_code}')
-
-    current_time = datetime.utcnow()
-    start_time = current_time - timedelta(days=2)
-    end_time = current_time - timedelta(days=1)
-    yesterday = {
-      "Start": start_time.strftime('%Y-%m-%d'),
-      "End": end_time.strftime('%Y-%m-%d')
-    }
-
+    yesterday = get_time_period_yesterday()
     cost, unit = utils.get_customer_cost(customer_id, yesterday, "DAILY")
     utils.report_cost(cost, customer_id, product_code)

--- a/sc_cost_meter/utils.py
+++ b/sc_cost_meter/utils.py
@@ -115,7 +115,6 @@ def get_marketplace_product_code(synapse_id):
 
     if "Item" in response.keys():
       product_code = response["Item"][ddb_product_code_attribute]["S"]
-      log.debug(f'marketplace product code: {product_code}')
     else:
       log.info(f'cannot find registration for synapse user: {synapse_id}')
 
@@ -150,12 +149,12 @@ def get_customer_cost(customer_id, time_period, granularity):
   results_by_time = response['ResultsByTime']
   cost = results_by_time[0]["Total"]["UnblendedCost"]["Amount"]
   unit = results_by_time[0]["Total"]["UnblendedCost"]["Unit"]
-  return cost, unit
+  return float(cost), unit
 
 def report_cost(cost, customer_id, product_code):
   '''
   Report the incurred cost of the customer's resources to the AWS Marketplace
-  :param cost: the cost
+  :param cost: the cost (as a float value)
   :param customer_id: the Marketplace customer ID
   :param product_code: the Marketplace product code
   '''

--- a/tests/unit/utils/test_get_customer_cost.py
+++ b/tests/unit/utils/test_get_customer_cost.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from botocore.stub import Stubber
+from sc_cost_meter import app, utils
+
+
+class TestGetCustomerCost(unittest.TestCase):
+
+  def test_get_cost(self):
+    client = utils.get_ce_client()
+    with Stubber(client) as stubber:
+      response = {
+        "ResultsByTime": [
+          {
+            "TimePeriod": {
+              "Start": "2020-11-09",
+              "End": "2020-11-10"
+            },
+            "Total": {
+              "UnblendedCost": {
+                "Amount": "0.2764",
+                "Unit": "USD"
+              }
+            },
+            "Groups": [],
+            "Estimated": True
+          }
+      ],
+        "ResponseMetadata": {
+          "RequestId": "9fb57117-bd89-4b4d-933a-ef487cd86177",
+          "HTTPStatusCode": 200,
+        }
+      }
+
+      expected = (0.2764, "USD")
+      stubber.add_response('get_cost_and_usage', response)
+      utils.get_ce_client = MagicMock(return_value=client)
+      yesterday = app.get_time_period_yesterday()
+      result = utils.get_customer_cost("111111", yesterday, "DAILY")
+      self.assertTupleEqual(expected, result)


### PR DESCRIPTION
We forgot to convert the cost that was read in from boto3 responseitt needs
be converted from a string to a float.  This is a fix for that.

Eror from cloudwatch..

[ERROR] TypeError: unsupported operand type(s) for /: 'str' and 'float'
Traceback (most recent call last):
  File "/var/task/sc_cost_meter/app.py", line 27, in lambda_handler
    utils.report_cost(cost, customer_id, product_code)
  File "/var/task/sc_cost_meter/utils.py", line 163, in report_cost
    quantity = int(cost / cost_accrued_rate)
[ERROR] TypeError: unsupported operand type(s) for /: 'str' and 'float'
Traceback (most recent call last):
File "/var/task/sc_cost_meter/app.py", line 27, in lambda_handler
utils.report_cost(cost, customer_id, product_code)
File "/var/task/sc_cost_meter/utils.py", line 163, in report_cost
quantity = int(cost / cost_accrued_rate)