### PR TITLE
[SC-255] handle metering failures

### DIFF
--- a/sc_cost_meter/app.py
+++ b/sc_cost_meter/app.py
@@ -22,8 +22,8 @@ def get_time_period_yesterday():
 def lambda_handler(event, context):
   synapse_ids = utils.get_marketplace_synapse_ids()
   log.debug(f'customers list: {synapse_ids}')
-  failures = 0
-  success = 0
+  num_customers = len(synapse_ids)
+  num_failed_reports = 0
   for synapse_id in synapse_ids:
     customer_info = utils.get_marketplace_customer_info(synapse_id)
     log.debug(f'marketplace customer info: {customer_info}')
@@ -36,15 +36,16 @@ def lambda_handler(event, context):
     cost, unit = utils.get_customer_cost(customer_id, yesterday, "DAILY")
     status, result = utils.report_cost(cost, customer_id, product_code)
     if status == 'Failed':
-      failures = failures + 1
+      num_failed_reports = num_failed_reports + 1
       log.info(f'Failed to report cost for product {product_code} to customer {customer_id}')
     else:
-      record_id = result['MeteringRecordId']
+      metering_record_id = result['MeteringRecordId']
       log.info(f'Successfully reported cost for product {product_code}'
-                f'to customer {customer_id} with record id {record_id}')
-      success = success + 1
+                f'to customer {customer_id} with record id {metering_record_id}')
 
-  message = f'Metering processed: failed reports ({failures}), successful reports ({success})'
+  num_success_reports = num_customers - num_failed_reports
+  message = f'Metering processed: failed reports ({num_failed_reports}),' \
+            f'successful reports ({num_success_reports})'
   log.info(message)
   response = {
     "statusCode": 200,
@@ -52,4 +53,4 @@ def lambda_handler(event, context):
       "message": message,
     }),
   }
-  return response
+

--- a/sc_cost_meter/app.py
+++ b/sc_cost_meter/app.py
@@ -22,6 +22,8 @@ def get_time_period_yesterday():
 def lambda_handler(event, context):
   synapse_ids = utils.get_marketplace_synapse_ids()
   log.debug(f'customers list: {synapse_ids}')
+  failures = 0
+  success = 0
   for synapse_id in synapse_ids:
     customer_info = utils.get_marketplace_customer_info(synapse_id)
     log.debug(f'marketplace customer info: {customer_info}')
@@ -32,12 +34,22 @@ def lambda_handler(event, context):
     product_code = customer_info['ProductCode']
     yesterday = get_time_period_yesterday()
     cost, unit = utils.get_customer_cost(customer_id, yesterday, "DAILY")
-    utils.report_cost(cost, customer_id, product_code)
+    status, result = utils.report_cost(cost, customer_id, product_code)
+    if status == 'Failed':
+      failures = failures + 1
+      log.info(f'Failed to report cost for product {product_code} to customer {customer_id}')
+    else:
+      record_id = result['MeteringRecordId']
+      log.info(f'Successfully reported cost for product {product_code}'
+                f'to customer {customer_id} with record id {record_id}')
+      success = success + 1
 
+  message = f'Metering processed: failed reports ({failures}), successful reports ({success})'
+  log.info(message)
   response = {
     "statusCode": 200,
     "body": json.dumps({
-      "message": "Metering processed",
+      "message": message,
     }),
   }
   return response

--- a/sc_cost_meter/app.py
+++ b/sc_cost_meter/app.py
@@ -53,4 +53,3 @@ def lambda_handler(event, context):
       "message": message,
     }),
   }
-

--- a/tests/unit/app/test_lambda_handler.py
+++ b/tests/unit/app/test_lambda_handler.py
@@ -20,7 +20,7 @@ class TestLambdaHandler(unittest.TestCase):
   @patch('sc_cost_meter.utils.get_customer_cost')
   @patch('sc_cost_meter.utils.report_cost')
   def test_report_cost_multiple_customers(self,
-                              mock_report_usage,
+                              mock_report_cost,
                               mock_get_cusomter_cost_yesterday,
                               mock_get_marketplace_customer_info,
                               mock_get_marketplace_synapse_ids):
@@ -30,7 +30,20 @@ class TestLambdaHandler(unittest.TestCase):
       'MarketplaceCustomerId': 'cust-1111',
       'ProductCode': 'prod-1234'
     }
-    mock_get_cusomter_cost_yesterday.return_value = ["2.1111", "USD"]
+    mock_get_cusomter_cost_yesterday.return_value = (2.1111, "USD")
+    mock_report_cost.return_value = (
+      'Success',
+      {
+        "UsageRecord": {
+          "Timestamp": "2020-10-10",
+          "CustomerIdentifier": "cust-123",
+          "Dimension": "costs_accrued",
+          "Quantity": 100
+        },
+        "MeteringRecordId": "rec-123",
+        "Status": "Success"
+      }
+    )
     app.lambda_handler(None, None)
-    mock_report_usage.called_with("2.1111", "cust-1111", "prod-1234")
-    self.assertEqual(mock_report_usage.call_count, 2)
+    mock_report_cost.called_with(2.1111, "cust-1111", "prod-1234")
+    self.assertEqual(mock_report_cost.call_count, 2)

--- a/tests/unit/utils/test_report_cost.py
+++ b/tests/unit/utils/test_report_cost.py
@@ -1,0 +1,83 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from botocore.stub import Stubber
+from sc_cost_meter import app, utils
+
+
+class TestReportCost(unittest.TestCase):
+
+  def test_report_cost_default_attempts_failed(self):
+    client = utils.get_meteringmarketplace_client()
+    with Stubber(client) as stubber:
+      responses = [
+        {},
+        {},
+        {}
+      ]
+      for response in responses:
+        stubber.add_response('batch_meter_usage', response)
+      utils.get_meteringmarketplace_client = MagicMock(return_value=client)
+      status, result = utils.report_cost(1.0, "cust-123", "prod-123")
+      expected = ("Failed", None)
+      self.assertEqual('Failed', status)
+      self.assertEqual(None, result)
+
+  def test_report_cost_non_default_attempts_failed(self):
+    client = utils.get_meteringmarketplace_client()
+    with Stubber(client) as stubber:
+      responses = [
+        {},
+        {},
+        {},
+        {},
+        {}
+      ]
+      for response in responses:
+        stubber.add_response('batch_meter_usage', response)
+      utils.get_meteringmarketplace_client = MagicMock(return_value=client)
+      status, result = utils.report_cost(1.0, "cust-123", "prod-123", 5)
+      expected = ("Failed", None)
+      self.assertEqual('Failed', status)
+      self.assertEqual(None, result)
+
+  def test_report_cost_success(self):
+    client = utils.get_meteringmarketplace_client()
+    with Stubber(client) as stubber:
+      response = {
+        "Results": [
+          {
+            "UsageRecord": {
+              "Timestamp": "2020-10-10",
+              "CustomerIdentifier":"cust-123",
+              "Dimension": "costs_accrued",
+              "Quantity": 100
+            },
+            "MeteringRecordId": "rec-123",
+            "Status": "Success"
+          }
+        ],
+        "UnprocessedRecords": [
+        ],
+        "ResponseMetadata": {
+          "RequestId": "066f8a74-f929-4595-bc19-1a16f605bed5",
+          "HTTPStatusCode": 200,
+        }
+      }
+      stubber.add_response('batch_meter_usage', response)
+      utils.get_meteringmarketplace_client = MagicMock(return_value=client)
+      status, result = utils.report_cost(1.0, "cust-123", "prod-123")
+      self.assertEqual('Success', status)
+      self.assertDictEqual(response['Results'][0], result)
+
+  def test_report_cost_invalid_attempts(self):
+    with self.assertRaises(ValueError):
+      utils.report_cost(1.0, "cust-123", "prod-123", 0)
+
+  def test_report_cost_invalid_cost_less_than_zero(self):
+    with self.assertRaises(ValueError):
+      utils.report_cost(-1.0, "cust-123", "prod-123")
+
+  def test_report_cost_invalid_cost_invalid_type_str(self):
+    with self.assertRaises(ValueError):
+      utils.report_cost("1.0", "cust-123", "prod-123")


### PR DESCRIPTION
Add retry logic in case sending cost report fails.  By default we attempt
to report 3 times before failing.